### PR TITLE
Fix Cloudflare Pages build — add root package.json

### DIFF
--- a/dashboard/wrangler.jsonc
+++ b/dashboard/wrangler.jsonc
@@ -1,7 +1,0 @@
-{
-  "name": "surry-dashboard",
-  "compatibility_date": "2026-06-11",
-  "assets": {
-    "directory": "./out"
-  }
-}

--- a/dashboard/wrangler.jsonc
+++ b/dashboard/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "surry-dashboard",
+  "compatibility_date": "2026-06-11",
+  "assets": {
+    "directory": "./out"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "github-slideshow",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "npm ci --prefix dashboard && npm run build --prefix dashboard"
+  }
+}


### PR DESCRIPTION
Cloudflare Pages runs `npm ci` at the repo root and fails because there's no `package.json` there (the app is in `dashboard/`).

This adds a minimal root `package.json` whose build script installs and builds the dashboard subdirectory:

```json
"build": "npm ci --prefix dashboard && npm run build --prefix dashboard"
```

**Updated Cloudflare Pages settings needed:**
- Build command: `npm run build`
- Build output directory: `dashboard/out`
- Root directory: *(leave empty)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbGx64Qwb7H9grzxy4fZPx)_